### PR TITLE
protect UDP socket before connection the remote server #4

### DIFF
--- a/app/src/main/java/xyz/hexene/localvpn/UDPOutput.java
+++ b/app/src/main/java/xyz/hexene/localvpn/UDPOutput.java
@@ -86,6 +86,7 @@ public class UDPOutput implements Runnable
                 DatagramChannel outputChannel = channelCache.get(ipAndPort);
                 if (outputChannel == null) {
                     outputChannel = DatagramChannel.open();
+                    vpnService.protect(outputChannel.socket());
                     try
                     {
                         outputChannel.connect(new InetSocketAddress(destinationAddress, destinationPort));
@@ -103,7 +104,6 @@ public class UDPOutput implements Runnable
                     selector.wakeup();
                     outputChannel.register(selector, SelectionKey.OP_READ, currentPacket);
 
-                    vpnService.protect(outputChannel.socket());
 
                     channelCache.put(ipAndPort, outputChannel);
                 }


### PR DESCRIPTION
If you add DNS server to the VPN,  a `UDPOutput` and `UDPInput` will not working. #4 

```java
private void setupVPN()
{
	if (vpnInterface == null)
	{
		Builder builder = new Builder();
		builder.addAddress(VPN_ADDRESS, 32);
		builder.addRoute(VPN_ROUTE, 0);
		builder.addDnsServer("8.8.8.8");
		vpnInterface = builder.setSession(getString(R.string.app_name)).setConfigureIntent(pendingIntent).establish();
	}
}
```

just call `vpnService.protect()` method before a socket connection to remote server.